### PR TITLE
feat: add queries for nvim-treesitter-textobjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains a thin wrapper around [ReScript parser for Tree-sitter](https://github.com/nkrkv/tree-sitter-rescript/) to make it an easy-to-install NeoVim plugin.
 
+Also included are queries for the [`nvim-treesitter/nvim-treesitter-textobjects`](https://github.com/nvim-treesitter/nvim-treesitter-textobjects) plugin which enable you to navigate, select, and modify ReScript code using text objects.
+
 ## Requirements
 
 - NeoVim 0.5.0+

--- a/queries/rescript/textobjects.scm
+++ b/queries/rescript/textobjects.scm
@@ -1,0 +1,113 @@
+; Queries for nvim-treesitter/nvim-treesitter-textobjects
+;--------------------------------------------------------
+
+; Classes (modules)
+;------------------
+
+(module_declaration definition: ((_) @class.inner)) @class.outer
+
+; Blocks
+;-------
+
+(block (_) @block.inner) @block.outer
+
+; Functions
+;----------
+
+(function body: (_) @function.inner) @function.outer
+
+; Calls
+;------
+
+(call_expression arguments: ((_) @call.inner)) @call.outer
+
+; Comments
+;---------
+
+(comment) @comment.outer
+
+; Parameters
+;-----------
+
+(function parameter: (_) @parameter.inner @parameter.outer)
+
+(formal_parameters
+  "," @_formal_parameters_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_formal_parameters_start @parameter.inner))
+(formal_parameters
+  . (_) @parameter.inner
+  . ","? @_formal_parameters_end
+  (#make-range! "parameter.outer" @parameter.inner @_formal_parameters_end))
+
+(arguments
+  "," @_arguments_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_arguments_start @parameter.inner))
+(arguments
+  . (_) @parameter.inner
+  . ","? @_arguments_end
+  (#make-range! "parameter.outer" @parameter.inner @_arguments_end))
+
+(function_type_parameters
+  "," @_function_type_parameters_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_function_type_parameters_start @parameter.inner))
+(function_type_parameters
+  . (_) @parameter.inner
+  . ","? @_function_type_parameters_end
+  (#make-range! "parameter.outer" @parameter.inner @_function_type_parameters_end))
+
+(functor_parameters
+  "," @_functor_parameters_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_functor_parameters_start @parameter.inner))
+(functor_parameters
+  . (_) @parameter.inner
+  . ","? @_functor_parameters_end
+  (#make-range! "parameter.outer" @parameter.inner @_functor_parameters_end))
+
+(type_parameters
+  "," @_type_parameters_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_type_parameters_start @parameter.inner))
+(type_parameters
+  . (_) @parameter.inner
+  . ","? @_type_parameters_end
+  (#make-range! "parameter.outer" @parameter.inner @_type_parameters_end))
+
+(type_arguments
+  "," @_type_arguments_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_type_arguments_start @parameter.inner))
+(type_arguments
+  . (_) @parameter.inner
+  . ","? @_type_arguments_end
+  (#make-range! "parameter.outer" @parameter.inner @_type_arguments_end))
+
+(decorator_arguments
+  "," @_decorator_arguments_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_decorator_arguments_start @parameter.inner))
+(decorator_arguments
+  . (_) @parameter.inner
+  . ","? @_arguments_end
+  (#make-range! "parameter.outer" @parameter.inner @_arguments_end))
+
+(variant_parameters
+  "," @_variant_parameters_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_variant_parameters_start @parameter.inner))
+(variant_parameters
+  . (_) @parameter.inner
+  . ","? @_variant_parameters_end
+  (#make-range! "parameter.outer" @parameter.inner @_variant_parameters_end))
+
+(polyvar_parameters
+  "," @_polyvar_parameters_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_polyvar_parameters_start @parameter.inner))
+(polyvar_parameters
+  . (_) @parameter.inner
+  . ","? @_polyvar_parameters_end
+  (#make-range! "parameter.outer" @parameter.inner @_polyvar_parameters_end))


### PR DESCRIPTION
Adds queries for the [`nvim-treesitter/nvim-treesitter-textobjects`](https://github.com/nvim-treesitter/nvim-treesitter-textobjects) plugin, enabling users to navigate, select, and modify ReScript code using text objects. See [nvim-treesitter-textobjects/CONTRIBUTING.md](https://github.com/nvim-treesitter/nvim-treesitter-textobjects/blob/master/CONTRIBUTING.md) for more info.

<details>
  <summary>Side note (click to expand)</summary>
  
Side note: This is only tangentially related to this PR, but while developing it I discovered a slight issue with the parsing of comment nodes; the node doesn't stop at the end of the comment, all of the whitespace after the comment is swallowed up too:

![2022-01-01_19-20-16_region](https://user-images.githubusercontent.com/21299126/147865166-68d1bad6-42ca-477f-a3ed-c8406c17bf38.png)

I can open a separate issue for this if you'd prefer.
</details>